### PR TITLE
Add support for a command wrapper for the app

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,3 +16,6 @@ markdown-it-py = {extras = ["plugins", "linkify"], version = "^2.1.0"}
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.poetry.scripts]
+mdex = "textual_markdown.browser_app:run"

--- a/textual_markdown/__main__.py
+++ b/textual_markdown/__main__.py
@@ -1,9 +1,6 @@
 import sys
 
-from .browser_app import BrowserApp
-
+from .browser_app import run
 
 if __name__ == "__main__":
-
-    app = BrowserApp()
-    app.run()
+    run()

--- a/textual_markdown/browser_app.py
+++ b/textual_markdown/browser_app.py
@@ -52,7 +52,5 @@ class BrowserApp(App):
     async def action_forward(self) -> None:
         await self.browser.forward()
 
-
-if __name__ == "__main__":
-    app = BrowserApp()
-    app.run()
+def run() -> None:
+    BrowserApp().run()


### PR DESCRIPTION
This should mean that it's easy enough to pipx install the project and then there's a nice handy command to run. I've chosen `mdex` (MarkDown EXplorer), but of course that's totally up to you.

This PR is more to suggest making this just a wee bit easier to run so it becomes a habit. :-)