### PR TITLE
Add keyboard shortcut 'r' to reload file

### DIFF
--- a/textual_markdown/browser_app.py
+++ b/textual_markdown/browser_app.py
@@ -15,6 +15,7 @@ class BrowserApp(App):
         ("t", "toggle_toc", "TOC"),
         ("b", "back", "Back"),
         ("f", "forward", "Forward"),
+        ("r", "reload", "Reload"),
     ]
 
     path = var("")
@@ -51,6 +52,9 @@ class BrowserApp(App):
 
     async def action_forward(self) -> None:
         await self.browser.forward()
+
+    async def action_reload(self) -> None:
+        await self.load(self.path)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This adds a keyboard shortcut, 'r', to reload the markdown file from disk.

Useful for reloading when actively editing the file